### PR TITLE
Fix function calls and add missing includes

### DIFF
--- a/imgui_tabs.cpp
+++ b/imgui_tabs.cpp
@@ -103,12 +103,12 @@ void ImGui::_drawPartialRect(const ImVec2 a, const ImVec2 b, const float roundin
                 dl->PathArcToFast(ImVec2(a.x+r3-shadow_offset,b.y-r3), r3, 3, 6);
                 dl->PathArcToFast(ImVec2(a.x+r0-shadow_offset,a.y+r0), r0, 6, 9);
                 dl->PathLineTo(ImVec2(a.x,b.y));
-                dl->PathFill(col);
+                dl->PathFillConvex(col);
             } if (shadow_edges & EDGE_RIGHT){
                 dl->PathArcToFast(ImVec2(b.x-r1+shadow_offset,a.y+r1), r1, 9, 12);
                 dl->PathArcToFast(ImVec2(b.x-r2+shadow_offset,b.y-r2), r2, 0, 3);
                 dl->PathLineTo(ImVec2(b.x,b.y));
-                dl->PathFill(col);
+                dl->PathFillConvex(col);
             }
         }
     }
@@ -268,9 +268,9 @@ void ImGui::TabBar::_drawTabBarBottom() {
     const ImVec2 pos = ImVec2(wind->Pos.x + wind->Size.x - padding.x, height);
 
     // Draw the background in a given color + alpha
-    dl->AddRectFilled(upperLeft, pos,ImColor(1.0f,1.0f,1.0f,0.15f),corner_rounding,ImGuiCorner_BottomLeft | ImGuiCorner_BottomRight);
+    dl->AddRectFilled(upperLeft, pos,ImColor(1.0f,1.0f,1.0f,0.15f),corner_rounding,ImGuiCorner_BotLeft | ImGuiCorner_BotRight);
     // Draw the border in a given color + alpha
-    dl->AddRect(upperLeft, pos,ImColor(1.0f,1.0f,1.0f,0.35f),corner_rounding,ImGuiCorner_BottomLeft | ImGuiCorner_TopRight);
+    dl->AddRect(upperLeft, pos,ImColor(1.0f,1.0f,1.0f,0.35f),corner_rounding,ImGuiCorner_BotLeft | ImGuiCorner_TopRight);
 
     dc.CursorPos += ImVec2(0,corner_rounding+2.0f); // Add all the extra height used above.
     ImGui::PopClipRect();

--- a/imgui_tabs.h
+++ b/imgui_tabs.h
@@ -69,6 +69,8 @@
 #define IMGUI_TABS_HPP
 
 #include <vector>
+#include <iostream>
+#include <string>
 #include "imgui.h"
 #include "imgui_internal.h"
 


### PR DESCRIPTION
In order for this library to work for me, I had to change some names of function calls (they may have changed with new versions of imgui) and there were missing includes (`string` and `iostream`).